### PR TITLE
Fix bugs where some zip files from macs don't get loaded correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # gtfs-utils
 
+[![](https://img.shields.io/pypi/v/gtfsutils.svg?style=for-the-badge)](https://pypi.python.org/pypi/gtfsutils)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/triply-at/gtfs-utils/test.yml?style=for-the-badge&label=test)](https://github.com/triply-at/gtfs-utils/actions/workflows/test.yml)
+
 gtfs-utils is a utility library for reading and filtering gtfs files that can handle large datasets.
 
 ## Simple example
@@ -10,7 +13,7 @@ Filter a gtfs feed by bounding box and save it to a new directory
 import gtfs_utils
 from gtfs_utils.filter import BoundsFilter
 
-gtfs = gtfs_utils.load_gtfs('vienna.zip', lazy=False)
+gtfs = gtfs_utils.load_gtfs_delayed('vienna.zip', lazy=False)
 filtered_gtfs = gtfs_utils.filter_gtfs(gtfs, [BoundsFilter(bounds=[16.2, 47.95, 16.35, 48.1], complete_trips=True)])
 filtered_gtfs.save('vienna_filtered')
 ```

--- a/gtfs_utils/__init__.py
+++ b/gtfs_utils/__init__.py
@@ -4,7 +4,7 @@ import importlib.metadata
 
 __version__ = importlib.metadata.version("gtfsutils")
 
-from .utils import load_gtfs, load_gtfs_delayed
+from .utils import load_gtfs_delayed
 from .utils import GtfsFile, DelayedGtfsDict
 
 from .info import get_info, get_bounding_box, get_calendar_date_range, get_route_types

--- a/gtfs_utils/cli/app.py
+++ b/gtfs_utils/cli/app.py
@@ -4,7 +4,11 @@ from typing import Annotated, Optional
 import typer
 from rich.console import Console
 
-from gtfs_utils import __version__, load_gtfs, GtfsFile, get_bounding_box
+from gtfs_utils import (
+    __version__,
+    get_bounding_box,
+    load_gtfs_delayed,
+)
 from gtfs_utils.cli import filter, info
 from gtfs_utils.cli.cli_utils import SourceArgument, LazyOption
 from gtfs_utils.info import get_route_type_counts
@@ -52,7 +56,7 @@ def bounds(
     src: SourceArgument,
     lazy: LazyOption = False,
 ):
-    df_dict = load_gtfs(src, lazy=lazy, subset=[GtfsFile.STOPS.file], only_subset=True)
+    df_dict = load_gtfs_delayed(src, lazy=lazy)
     bbox = get_bounding_box(df_dict)
 
     console = Console()
@@ -71,7 +75,7 @@ def route_types(
         ),
     ] = False,
 ):
-    df_dict = load_gtfs(src, lazy=lazy, subset=[GtfsFile.ROUTES.file], only_subset=True)
+    df_dict = load_gtfs_delayed(src, lazy=lazy)
     route_counts = get_route_type_counts(df_dict)
 
     console = Console()

--- a/gtfs_utils/info.py
+++ b/gtfs_utils/info.py
@@ -2,7 +2,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
-from .utils import load_gtfs, GtfsDict, compute_if_necessary
+from . import load_gtfs_delayed
+from .utils import GtfsDict, compute_if_necessary
 
 
 @dataclass
@@ -20,7 +21,7 @@ def get_info(src: Path | GtfsDict) -> GtfsInfo:
     :param src: Path to GTFS directory or zip file, or a dictionary of DataFrames
     :return: a GtfsInfo object for the feed
     """
-    df_dict = load_gtfs(src) if isinstance(src, Path) else src
+    df_dict = load_gtfs_delayed(src) if isinstance(src, Path) else src
     date_range = get_calendar_date_range(src)
     file_size = {}
     for file in df_dict:
@@ -32,19 +33,19 @@ def get_info(src: Path | GtfsDict) -> GtfsInfo:
 
 
 def get_route_types(src: Path | GtfsDict) -> list[int]:
-    df_dict = load_gtfs(src) if isinstance(src, Path) else src
+    df_dict = load_gtfs_delayed(src) if isinstance(src, Path) else src
 
     return compute_if_necessary(df_dict.routes()["route_type"].unique()).tolist()
 
 
 def get_route_type_counts(src: Path | GtfsDict) -> dict[int, int]:
-    df_dict = load_gtfs(src) if isinstance(src, Path) else src
+    df_dict = load_gtfs_delayed(src) if isinstance(src, Path) else src
 
     return compute_if_necessary(df_dict.routes()["route_type"].value_counts()).to_dict()
 
 
 def get_calendar_date_range(src: Path | GtfsDict) -> tuple[datetime, datetime]:
-    df_dict = load_gtfs(src) if isinstance(src, Path) else src
+    df_dict = load_gtfs_delayed(src) if isinstance(src, Path) else src
 
     if "calendar" in df_dict:
         calendar = df_dict["calendar"]
@@ -71,7 +72,7 @@ def get_calendar_date_range(src: Path | GtfsDict) -> tuple[datetime, datetime]:
 
 
 def get_bounding_box(src: Path | GtfsDict) -> tuple[float, float, float, float]:
-    df_dict = load_gtfs(src) if isinstance(src, Path) else src
+    df_dict = load_gtfs_delayed(src) if isinstance(src, Path) else src
 
     stops = df_dict["stops"]
     return compute_if_necessary(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gtfsutils"
-version = "0.2.1"
+version = "0.2.2"
 description = "Utility library for working with gtfs files"
 readme = "README.md"
 authors = [

--- a/tests/test_filter_bounds.py
+++ b/tests/test_filter_bounds.py
@@ -27,7 +27,7 @@ def vienna_data_path(data_dir):
 
 
 def test__filter_with_empty_bounds(vienna_data_path, lazy):
-    gtfs = gtfs_utils.load_gtfs(vienna_data_path, lazy=lazy)
+    gtfs = gtfs_utils.load_gtfs_delayed(vienna_data_path, lazy=lazy)
 
     assert isinstance(gtfs, GtfsDict)
     for key in gtfs:
@@ -53,7 +53,7 @@ def test__filter_bounds_vienna(
     complete_trips,
     expected_stops,
 ):
-    gtfs = gtfs_utils.load_gtfs(vienna_data_path, lazy=lazy)
+    gtfs = gtfs_utils.load_gtfs_delayed(vienna_data_path, lazy=lazy)
 
     filtered = gtfs_utils.filter_gtfs(
         gtfs, [BoundsFilter(bounds=vienna_south_bounds, complete_trips=complete_trips)]
@@ -70,7 +70,7 @@ def test__filter_by_own_bounds(vienna_data_path, lazy):
     """
     Filtering a gtfs feed by its own bounds -> Should return the same feed
     """
-    gtfs = gtfs_utils.load_gtfs(vienna_data_path, lazy=lazy)
+    gtfs = gtfs_utils.load_gtfs_delayed(vienna_data_path, lazy=lazy)
     file_sizes = {key: len(gtfs[key]) for key in gtfs}
     bounds = gtfs.bounds()
 

--- a/tests/test_filter_route_types.py
+++ b/tests/test_filter_route_types.py
@@ -17,7 +17,7 @@ def sample_data(data_dir):
 
 
 def test__filter_with_all_route_types(sample_data, lazy):
-    gtfs = gtfs_utils.load_gtfs(sample_data, lazy=lazy)
+    gtfs = gtfs_utils.load_gtfs_delayed(sample_data, lazy=lazy)
 
     file_sizes = {key: len(gtfs[key]) for key in gtfs}
 
@@ -32,7 +32,7 @@ def test__filter_with_all_route_types(sample_data, lazy):
 
 
 def test__filter_with_all_route_types_negated(sample_data, lazy):
-    gtfs = gtfs_utils.load_gtfs(sample_data, lazy=lazy)
+    gtfs = gtfs_utils.load_gtfs_delayed(sample_data, lazy=lazy)
 
     filtered = gtfs_utils.filter_gtfs(
         gtfs, [RouteTypeFilter(route_types=ROUTE_TYPES.keys(), negate=True)]
@@ -45,7 +45,7 @@ def test__filter_with_all_route_types_negated(sample_data, lazy):
 
 
 def test__filter_by_type_3(sample_data, lazy):
-    gtfs = gtfs_utils.load_gtfs(sample_data, lazy=lazy)
+    gtfs = gtfs_utils.load_gtfs_delayed(sample_data, lazy=lazy)
 
     assert isinstance(gtfs, GtfsDict)
     for key in gtfs:

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -29,7 +29,7 @@ def sample_gtfs_path(data_dir, request):
 
 @pytest.fixture
 def sample_gtfs(sample_gtfs_path, lazy):
-    return gtfs_utils.load_gtfs(sample_gtfs_path, lazy=lazy)
+    return gtfs_utils.load_gtfs_delayed(sample_gtfs_path, lazy=lazy)
 
 
 def test__get_bounding_box(sample_gtfs):

--- a/uv.lock
+++ b/uv.lock
@@ -404,7 +404,7 @@ wheels = [
 
 [[package]]
 name = "gtfsutils"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "dask", extra = ["dataframe"] },


### PR DESCRIPTION
Before this PR, `load_gtfs_delayed` did not load data from the `vienna.zip` file correctly sometimes.
We now use `load_gtfs_delayed` instead of `load_gtfs` for all usages and I've gone ahead and deprecated `load_gtfs`.